### PR TITLE
Support 0.14.0-beta1

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "peerDependencies": {
     "moment": ">=2.8.0",
-    "react": ">=0.12.0"
+    "react": ">=0.12.0 || 0.13.0-beta.1 || 0.13.0-rc1 || 0.13.0-rc2 || 0.14.0-beta1"
   },
   "devDependencies": {
     "babel-loader": "^5.1.4",


### PR DESCRIPTION
Support beta versions in peerDependencies

Because it seems that we can't use the new beta as NPM do weird things :(

This solution seems to be adopted by React Hot Loader too, see https://github.com/gaearon/react-hot-api/issues/18