### PR TITLE
Fix calendar on IE11

### DIFF
--- a/index.jsx
+++ b/index.jsx
@@ -12,7 +12,7 @@ var pickerDate = NOW
 
 var sizeStyle = {
     width: 300,
-    minHeight: 280
+    height: 280
 }
 
 var LOCALE = 'en'


### PR DESCRIPTION
This should fix #47 in regards to the demo page. The problem isn't really the date picker but rather it's parent, it seems to be some obscure bug with min-height.

[Here's some reading marterial about the bug](http://philipwalton.com/articles/normalizing-cross-browser-flexbox-bugs/) by Philip Walton if someone is interested.