### PR TITLE
#64 add event to function signature

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -483,7 +483,7 @@ var DatePicker = React.createClass({
         }
     },
 
-    handleRangeChange: function handleRangeChange(mom) {
+    handleRangeChange: function handleRangeChange(mom, event) {
         var _this2 = this;
 
         var range = this.p.range;


### PR DESCRIPTION
This should fix #64 as it extends the function signature to expect `event` too, but you better look into it. Also sorry for the newline at the end, that's Github's fault though.