### PR TITLE
weekends should depends on the first day of the week

### DIFF
--- a/src/BasicMonthView.js
+++ b/src/BasicMonthView.js
@@ -33,6 +33,25 @@ const getWeekStartDay = (props) => {
 }
 
 /**
+ * Gets the number for the first day of the weekend
+ *
+ * @param  {Object} props
+ * @param  {Number/String} props.weekStartDay
+ *
+ * @return {Number}
+ */
+const getWeekendStartDay = (props) => {
+  let weekendStartDay = props.weekendStartDay
+  const weekStartDay = getWeekStartDay(props)
+
+  if (weekendStartDay == null) {
+    weekendStartDay = weekStartDay + 5 % 7
+  }
+
+  return weekendStartDay
+}
+
+/**
  * Gets a moment that points to the first day of the week
  *
  * @param  {Moment/Date/String} value]
@@ -427,5 +446,6 @@ export default BasicMonthView
 export {
   getWeekStartDay,
   getWeekStartMoment,
+  getWeekendStartDay,
   getDaysInMonthView
 }

--- a/src/MonthView/index.js
+++ b/src/MonthView/index.js
@@ -16,7 +16,7 @@ import bemFactory from '../bemFactory'
 import joinFunctions from '../joinFunctions'
 import assignDefined from '../assignDefined'
 
-import BasicMonthView, { getDaysInMonthView } from '../BasicMonthView'
+import BasicMonthView, { getDaysInMonthView, getWeekendStartDay } from '../BasicMonthView'
 
 import ON_KEY_DOWN from './onKeyDown'
 import NAV_KEYS from './navKeys'
@@ -371,9 +371,11 @@ export default class MonthView extends Component {
   }
 
   prepareWeekendClassName(dateMoment, { highlightWeekends }) {
+    const props = this.p
     const weekDay = dateMoment.day()
+    const weekendStartDay = getWeekendStartDay(props)
 
-    if (weekDay === 0 /* Sunday */ || weekDay === 6 /* Saturday */) {
+    if (weekDay === weekendStartDay || weekDay === weekendStartDay + 1) {
       return join(
         this.bem('day--weekend'),
         highlightWeekends && this.bem('day--weekend-highlight')

--- a/src/config.js
+++ b/src/config.js
@@ -8,6 +8,9 @@ export default {
   //the day to display as first day of week. defaults to 0, which is sunday
   weekStartDay: null,
 
+  //the day the weekend starts on. defaults to 6, which is saturday
+  weekendStartDay: null,
+
   locale: null,
 
   //the format in which days should be displayed in month view


### PR DESCRIPTION
In locales where the first day of the week isn't Monday, the weekend is naturally not "Saturday - Sunday" either.

This pull request highlights the weekend depending on the first day of the week, as well as adds a prop to override this setting. 