### PR TITLE
expose `arrows` prop on DatePicker

### DIFF
--- a/src/DateField/index.js
+++ b/src/DateField/index.js
@@ -376,6 +376,7 @@ export default class DateField extends Component {
 
         dateFormat: props.dateFormat,
         theme: props.theme || pickerProps.theme,
+        arrows: props.arrows,
 
         className: join(pickerProps.className, 'react-date-field__picker'),
 

--- a/src/MonthView/index.js
+++ b/src/MonthView/index.js
@@ -689,6 +689,7 @@ export default class MonthView extends Component {
           viewMoment: props.viewMoment,
           onViewDateChange: this.onNavViewDateChange,
           onMouseDown: this.onNavMouseDown,
+          arrows: props.arrows,
           ref
         }, {
           enableHistoryView: props.enableHistoryView

--- a/src/config.js
+++ b/src/config.js
@@ -37,6 +37,9 @@ export default {
 
   maxDate: null,
 
+  //allows to override the arrows icons for the navigation bar
+  arrows: null,
+
   //the date where to open the picker. defaults to today if no date and no viewDate specified
   viewDate: null,
 


### PR DESCRIPTION
Exposes the arrows prop for NavBar on DatePicker

Related to this issue:
https://github.com/zippyui/react-date-picker/issues/112