### PR TITLE
consider defaultValue, not only value

### DIFF
--- a/src/ClockInput.js
+++ b/src/ClockInput.js
@@ -37,7 +37,7 @@ export default class ClockInput extends Component {
 
     this.dateFormat = dateFormat
 
-    this.value = props.value !== undefined ? props.value : this.state.value
+    this.value = props.value !== undefined ? props.value : props.defaultValue !== undefined ? props.defaultValue : this.state.value
 
     const className = join(
       props.className,


### PR DESCRIPTION
regarding https://github.com/zippyui/react-date-picker/issues/140

When ClockInput is rendered via Calendar and without readonly flag, Calendar assigns the ClockInput a `defaultValue`, not a `value`, in https://github.com/zippyui/react-date-picker/blob/master/src/Calendar.js#L142

This change uses `defaultValue` if no `value` was set before falling back to state