### PR TITLE
#124 Set time to now when only date is selected

### DIFF
--- a/src/DateField/index.js
+++ b/src/DateField/index.js
@@ -482,7 +482,7 @@ export default class DateField extends Component {
     if (activeDate) {
       const date = this.toMoment(activeDate)
 
-      forwardTime(this.time, date)
+      forwardTime(this.time || moment(), date)
 
       this.setValue(date, { skipTime: !!this.time })
     }


### PR DESCRIPTION
When opening the calendar (with time selector) without a value, the time displayed is "now".
If the user selects only a date, then the time selected is "00:00" => it should select what was displayed (in case the user didn't want to change the time!)

This PR ensure that the selected time is what's displayed in these conditions

(this should solve issue #124 )