### PR TITLE
Fix unknown props warnings for v4

### DIFF
--- a/src/MonthView.jsx
+++ b/src/MonthView.jsx
@@ -161,6 +161,10 @@ var MonthView = React.createClass({
     }
 
     if (result === undefined){
+      delete weekNumberProps.week
+      delete weekNumberProps.days
+      delete weekNumberProps.date
+
       result = <div {...weekNumberProps} />
     }
 
@@ -298,11 +302,16 @@ var MonthView = React.createClass({
     }
 
     var defaultRenderFunction = React.DOM.div
-    var renderFunction = props.renderDay || defaultRenderFunction
-
-    var result = renderFunction(renderDayProps)
+    var result
+    if (props.renderDay) {
+       result = renderFunction(renderDayProps)
+    }
 
     if (result === undefined){
+      delete renderDayProps.text
+      delete renderDayProps.date
+      delete renderDayProps.moment
+
       result = defaultRenderFunction(renderDayProps)
     }
 

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -207,8 +207,37 @@ var DatePicker = React.createClass({
         viewProps.highlightRangeOnMouseMove = this.props.highlightRangeOnMouseMove
         viewProps.range = props.range
 
+        var divProps = assign({}, this.props)
+
+        delete divProps.locale
+        delete divProps.weekNumbers
+        delete divProps.defaultDate
+        delete divProps.xweekDayNames
+        delete divProps.weekDayNames
+        delete divProps.weekStartDay
+        delete divProps.dayFormat
+        delete divProps.monthFormat
+        delete divProps.yearFormat
+        delete divProps.navPrev
+        delete divProps.navNext
+        delete divProps.view
+        delete divProps.minDate
+        delete divProps.maxDate
+        delete divProps.dateFormat
+        delete divProps.onRenderDay
+        delete divProps.renderDay
+        delete divProps.alwaysShowPrevWeek
+        delete divProps.weekNumberName
+        delete divProps.isDatePicker
+        delete divProps.navOnDateClick
+        delete divProps.highlightRangeOnMouseMove
+        delete divProps.defaultStyle
+        delete divProps.onRangeChange
+        delete divProps.xweekStartDay
+        delete divProps.highlightWeekends
+
         return (
-            <div {...this.props} className={className} style={props.style} >
+            <div {...divProps} className={className} style={props.style} >
                 {this.renderHeader(view, props)}
 
                 <div className="dp-body" style={{flex: 1}}>


### PR DESCRIPTION
I am using v4 of your great library with a lot of theme customizations and I want to migrate to React 15. Looks like it is easier to fix 'unknown props' warnings in v4 instead of migrating to v5 (and change all the custom css I have). 