### PR TITLE
Fix non-functional Numpad digits on DateFormatInput

### DIFF
--- a/src/DateFormatInput/formats.js
+++ b/src/DateFormatInput/formats.js
@@ -65,7 +65,8 @@ const handleUpdate = (value, format, { range }) => {
 }
 
 const handleUnidentified = (format, { event, currentValue, range }) => {
-  const newChar = String.fromCharCode(event.which)
+  const which = event.which
+  const newChar = String.fromCharCode(96 <= which && which <= 105 ? which - 48 : which)
   let index = range.start - format.start
 
   const caretPos = { start: range.start + 1 }


### PR DESCRIPTION
Fix a bug where Numpad digits was not working on ClockInput.
The reason is quite explicit on this stackoverflow comment : http://stackoverflow.com/a/5829387